### PR TITLE
Added API Response to onSucess

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -98,7 +98,7 @@ export const createEntity = (entity, {
       })
     }).then(json => {
       dispatch(apiCreated(json.data));
-      onSuccess();
+      onSuccess(json);
     }).catch(error => {
       const err = error;
       err.entity = entity;
@@ -122,7 +122,7 @@ export const readEndpoint = (endpoint, {
     apiRequest(`${apiEndpoint}`, accessToken)
       .then(json => {
         dispatch(apiRead({ endpoint, ...json }));
-        onSuccess();
+        onSuccess(json);
       })
       .catch(error => {
         const err = error;
@@ -151,7 +151,7 @@ export const updateEntity = (entity, {
       })
     }).then((response) => {
       dispatch(apiUpdated(response.data));
-      onSuccess();
+      onSuccess(response);
     }).catch(error => {
       const err = error;
       err.entity = entity;

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -149,9 +149,9 @@ export const updateEntity = (entity, {
       body: JSON.stringify({
         data: entity
       })
-    }).then((response) => {
-      dispatch(apiUpdated(response.data));
-      onSuccess(response);
+    }).then(json => {
+      dispatch(apiUpdated(json.data));
+      onSuccess(json);
     }).catch(error => {
       const err = error;
       err.entity = entity;


### PR DESCRIPTION
Adding responses to __onSuccess__ callback, as first parameter on:

1. __readEndpoint__ returns JSON parameter.
1. __createEntity__ returns JSON parameter.
1. __updateEntity__ return JSON parameter.
