### PR TITLE
[1.3.5] Fix issue with content-type parsing

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -62,7 +62,7 @@ export const uploadFile = (file, {
     return fetch(url, options)
       .then(res => {
         if (res.status >= 200 && res.status < 300) {
-          if (jsonContentTypes.indexOf(res.headers.get('Content-Type')) > -1) {
+          if (jsonContentTypes.some(contentType => res.headers.get('Content-Type').indexOf(contentType) > -1)) {
             return res.json();
           }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,7 @@ export const apiRequest = (url, accessToken, options = {}) => {
   return fetch(url, allOptions)
     .then(res => {
       if (res.status >= 200 && res.status < 300) {
-        if (jsonContentTypes.indexOf(res.headers.get('Content-Type')) > -1) {
+        if (jsonContentTypes.some(contentType => res.headers.get('Content-Type').indexOf(contentType) > -1)) {
           return res.json();
         }
 


### PR DESCRIPTION
Issue occurred when content-type header would contains other params, e.g. charset. The check if a valid JSON content-type was responded with, did not pass and the module would not attempt to parse the body as JSON.

Linked issues: #13 #14 #15 