### PR TITLE
Add Accept header (required by some JSON API implementations)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,8 @@ export const apiRequest = (url, accessToken, options = {}) => {
   const allOptions = {
     headers: {
       Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/vnd.api+json'
+      'Content-Type': 'application/vnd.api+json',
+      'Accept': 'application/vnd.api+json'
     },
     ...options
   };


### PR DESCRIPTION
It's a small detail, but in some cases it makes the whole library unusable.

Some implementations of the `fetch` API send an `Accept: */*` parameter, which doesn't work well with many APIs (such as Flask and Tornado JSON API implementations). 
According to the JSON API specification there shouldn't be any issues caused by sending this header in every request, and it seems to solve the problem.

Maybe it would be useful to be able to edit the default headers for fetch calls in a future release.