### PR TITLE
Fixed API_{UPDATE|DELETE}_FAILED reducers.

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -318,7 +318,7 @@ export const reducer = handleActions({
       .toJS();
   },
 
-  [API_UPDATE_FAILED]: (rawState, { payload: entity }) => {
+  [API_UPDATE_FAILED]: (rawState, { payload: { entity } }) => {
     const { type, id } = entity;
     const state = Imm.fromJS(rawState);
 
@@ -345,7 +345,7 @@ export const reducer = handleActions({
       .toJS();
   },
 
-  [API_DELETE_FAILED]: (rawState, { payload: entity }) => {
+  [API_DELETE_FAILED]: (rawState, { payload: { entity } }) => {
     const { type, id } = entity;
     const state = Imm.fromJS(rawState);
 


### PR DESCRIPTION
Payload should be passed as `{type: ..., id: ...}` but actually it passed as `{entity: {type: ..., id: ...}}` on `API_UPDATE_FAILED` and `API_DELETE_FAILED`.