### PR TITLE
Allow `fetch` to send cookies

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,8 @@ export const apiRequest = (url, accessToken, options = {}) => {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/vnd.api+json',
-      Accept: 'application/vnd.api+json'
+      Accept: 'application/vnd.api+json',
+      credentials: 'same-origin'
     },
     ...options
   };


### PR DESCRIPTION
I made it due to websites usually requires cookies to authenticate users somehow. Doc: https://github.com/github/fetch#sending-cookies

We have to allow users to edit `fetch` params somehow.