### PR TITLE
fix return value for updateReverseRelationship

### DIFF
--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -30,7 +30,7 @@ const updateReverseRelationship = (
             }
 
             if (!relation) {
-              return [newRelation];
+              return new Imm.List([newRelation]);
             }
 
             return relation.push(newRelation);

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -235,28 +235,52 @@ const responseDataWithSingleEntity = {
 };
 
 const responseDataWithOneToManyRelationship = {
-  data: {
-    type: 'companies',
-    id: '1',
-    attributes: {
-      name: 'Dixie.io',
-      slug: 'dixie.io',
-      createdAt: '2016-04-08T08:42:45+0000',
-      updatedAt: '2016-04-08T08:42:45+0000'
-    },
-    relationships: {
-      user: {
-        data: {
-          type: 'users',
-          id: '1'
+  data: [
+    {
+      type: 'companies',
+      id: '1',
+      attributes: {
+        name: 'Dixie.io',
+        slug: 'dixie.io',
+        createdAt: '2016-04-08T08:42:45+0000',
+        updatedAt: '2016-04-08T08:42:45+0000'
+      },
+      relationships: {
+        user: {
+          data: {
+            type: 'users',
+            id: '1'
+          }
         }
+      },
+      links: {
+        self: 'http:\/\/gronk.app\/api\/v1\/companies\/1'
       }
     },
-    links: {
-      self: 'http:\/\/gronk.app\/api\/v1\/companies\/1'
+    {
+      type: 'companies',
+      id: '2',
+      attributes: {
+        name: 'Dixie.io',
+        slug: 'dixie.io',
+        createdAt: '2016-04-08T08:42:45+0000',
+        updatedAt: '2016-04-08T08:42:45+0000'
+      },
+      relationships: {
+        user: {
+          data: {
+            type: 'users',
+            id: '1'
+          }
+        }
+      },
+      links: {
+        self: 'http:\/\/gronk.app\/api\/v1\/companies\/2'
+      }
     }
-  }
+  ]
 };
+
 
 describe('Creation of new entities', () => {
   it('should automatically organize new entity in new key on state', () => {


### PR DESCRIPTION
Currently the updateReverseRelationship function returns the length of the array instead of the relation list on line 36 when there are multiple entities in the response data. This naturally results in an error.
 
Creating the newRelation as an immutable list should fix it.