### PR TITLE
Add .nvmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 .node_repl_history
 
 lib
+
+# node version manager settings
+.nvmrc


### PR DESCRIPTION
I'm the person who's using node version manager, https://github.com/creationix/nvm . I set up `.nvmrc` file for every js project, but I don't think I have to commit it here...