### PR TITLE
Relationships with no matching foreign entity may updated other entities incorrectly

### DIFF
--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -10,10 +10,16 @@ const updateReverseRelationship = (
   }
 ) => {
   return (foreignEntities) => {
+    const idx = foreignEntities.findIndex(
+      item => item.get('id') === relationship.getIn(['data', 'id'])
+    );
+
+    if (idx === -1) {
+      return foreignEntities;
+    }
+
     return foreignEntities.update(
-      foreignEntities.findIndex(
-        item => item.get('id') === relationship.getIn(['data', 'id'])
-      ),
+      idx,
       foreignEntity => {
         const [singular, plural] = [1, 2].map(i => pluralize(entity.get('type'), i));
         const relCase = [singular, plural].find(r => foreignEntity.hasIn(['relationships', r]));

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -31,7 +31,7 @@ const state = {
     data: [
       {
         type: 'users',
-        id: 1,
+        id: '1',
         attributes: {
           name: 'John Doe'
         },
@@ -127,7 +127,7 @@ const transactionToDelete = {
 
 const updatedUser = {
   type: 'users',
-  id: 1,
+  id: '1',
   attributes: {
     name: 'Sir John Doe'
   },

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -281,6 +281,7 @@ const responseDataWithOneToManyRelationship = {
   ]
 };
 
+const payloadWithNonMatchingReverseRelationships = require('./payloads/withNonMatchingReverseRelationships.json');
 
 describe('Creation of new entities', () => {
   it('should automatically organize new entity in new key on state', () => {
@@ -331,6 +332,19 @@ describe('Reading entities', () => {
     expect(updatedState.users).toBeAn('object');
     expect(updatedState.companies).toBeAn('object');
     expect(updatedState.users.data[0].relationships.companies.data).toBeAn('array');
+  });
+
+  it('should ignore reverse relationship with no matching entity', () => {
+    const updatedState = reducer(state, apiRead(payloadWithNonMatchingReverseRelationships));
+
+    payloadWithNonMatchingReverseRelationships.included
+      .filter(entity => entity.type === 'reports')
+      .forEach(
+        payloadReport => {
+          const stateReport = updatedState.reports.data.find(r => payloadReport.id === r.id);
+          expect(stateReport.relationships.file.data.id).toEqual(payloadReport.relationships.file.data.id);
+        }
+      );
   });
 });
 

--- a/test/payloads/withNonMatchingReverseRelationships.json
+++ b/test/payloads/withNonMatchingReverseRelationships.json
@@ -1,0 +1,57 @@
+{
+  "data": [],
+  "included": [
+    {
+      "type": "reports",
+      "id": "121",
+      "attributes": { },
+      "relationships": {
+        "file": {
+          "data": {
+            "type": "files",
+            "id": "9979"
+          }
+        }
+      }
+    },
+    {
+      "type": "files",
+      "id": "210",
+      "attributes": { },
+      "relationships": {
+        "fileable": {
+          "data": {
+            "type": "reports",
+            "id": "13"
+          }
+        }
+      }
+    },
+    {
+      "type": "reports",
+      "id": "122",
+      "attributes": { },
+      "relationships": {
+        "file": {
+          "data": {
+            "type": "files",
+            "id": "9980"
+          }
+        }
+      }
+    },
+    {
+      "type": "files",
+      "id": "666",
+      "attributes": { },
+      "relationships": {
+        "fileable": {
+          "data": {
+            "type": "reports",
+            "id": "16"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
In cases where an entity has a relationship of which it's foreign entity does not exist in the state, the last entity of same type will be wrongfully updated to have it's reverse relationship updated.