### PR TITLE
Allow any headers in requests

### DIFF
--- a/docs/set-up-configure.md
+++ b/docs/set-up-configure.md
@@ -34,9 +34,20 @@ Since most of _redux-json-api_'s are async it is required to configure your stor
 
 ## Configure API endpoints and access token
 
-As _redux-json-api_ will automatically make request to your API, it requires to know about API host, root path and access token.
+As _redux-json-api_ will automatically make requests to your API, it requires to know about API host, root path and any headers, such as an access token.
 
-There are one method for each of these, and they should be dispatched before dispatching any CRUD actions.
+#### Defaults
+
+By default, without the host and root path being set, all requests will be made to the current host at root (example: `/tasks`) with the following headers:
+
+```js
+  headers: {
+    'Content-Type': 'application/vnd.api+json',
+    Accept: 'application/vnd.api+json'
+  }
+```
+
+To change any of the defaults, the appropriate `set` methods should be dispatched before dispatching any CRUD actions.
 
 #### `setEndpointHost( hostWithProtocol: string ): object`
 
@@ -64,4 +75,24 @@ dispatch(setEndpointPath('v1'));
 
 #### `setAccessToken( accessToken: string ): object`
 
-Dispatch this action to configure an access token to include in all requests. At the moment, _redux-json-api_ only supports authorizing requests through the `Authorization: Bearer <accessToken>` header.
+Dispatch this action to configure an access token to include in all requests.
+This will in turn dispatch a setHeader request, setting the header up as
+`Authorization: Bearer <accessToken>`.
+
+#### `setHeader( headers: object ): object`
+
+Dispatch this action to configure any headers to be included in all requests.
+The singular 'setHeader' action will merge in the given header(s).
+
+#### `setHeaders( headers: object ): object`
+
+Dispatch this action to completely reset the headers, removing all defaults.
+The equivalent of ```dispatch(setAccessToken('myToken123'))``` is:
+
+```js
+dispatch(setHeaders({
+  Authorization: `Bearer myToken123`,
+  'Content-Type': 'application/vnd.api+json',
+  Accept: 'application/vnd.api+json'
+}));
+```

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,8 @@ import keykey from 'keykey';
 export default keykey(
   'API_SET_ENDPOINT_HOST',
   'API_SET_ENDPOINT_PATH',
-  'API_SET_ACCESS_TOKEN',
+  'API_SET_HEADERS',
+  'API_SET_HEADER',
   'API_WILL_CREATE',
   'API_CREATED',
   'API_CREATE_FAILED',

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,17 +5,8 @@ export const jsonContentTypes = [
 
 export const noop = () => {};
 
-export const apiRequest = (url, accessToken, options = {}) => {
-  const allOptions = {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/vnd.api+json',
-      Accept: 'application/vnd.api+json'
-    },
-    ...options
-  };
-
-  return fetch(url, allOptions)
+export const apiRequest = (url, options = {}) => {
+  return fetch(url, options)
     .then(res => {
       if (res.status >= 200 && res.status < 300) {
         if (jsonContentTypes.some(contentType => res.headers.get('Content-Type').indexOf(contentType) > -1)) {

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -6,7 +6,8 @@ import { createAction } from 'redux-actions';
 import expect from 'expect';
 import {
   reducer,
-  setAccessToken,
+  setHeaders,
+  setHeader,
   setEndpointHost,
   setEndpointPath,
   IS_DELETING,
@@ -25,7 +26,10 @@ const state = {
   endpoint: {
     host: null,
     path: null,
-    accessToken: null
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      Accept: 'application/vnd.api+json'
+    }
   },
   users: {
     data: [
@@ -376,11 +380,27 @@ describe('Delete entities', () => {
 });
 
 describe('Endpoint values', () => {
-  it('should update to provided access token', () => {
+  it('should default to jsonapi content type and accept headers', () => {
+    const initialState = reducer(undefined, { type: '@@INIT' });
+    expect(initialState.endpoint.headers).toEqual({
+      'Content-Type': 'application/vnd.api+json',
+      Accept: 'application/vnd.api+json'
+    });
+  });
+
+  it('should update provided header, such as an access token', () => {
     const at = 'abcdef0123456789';
-    expect(state.endpoint.accessToken).toNotEqual(at);
-    const updatedState = reducer(state, setAccessToken(at));
-    expect(updatedState.endpoint.accessToken).toEqual(at);
+    const header = { Authorization: `Bearer ${at}` };
+    expect(state.endpoint.headers).toNotMatch(header);
+    const updatedState = reducer(state, setHeader(header));
+    expect(updatedState.endpoint.headers).toMatch(header);
+  });
+
+  it('should update to provided custom headers', () => {
+    const headers = { Custom: 'headers' };
+    expect(state.endpoint.headers).toNotEqual(headers);
+    const updatedState = reducer(state, setHeaders(headers));
+    expect(updatedState.endpoint.headers).toEqual(headers);
   });
 
   it('should update to provided endpoint host and path', () => {


### PR DESCRIPTION
I needed to have CSRF tokens submitted as part of a section of a 'mostly' server side HTML rails app. I updated the docs with how it works, and left 'setAccessToken' action intact.