### PR TITLE
`setEndpointFetchMode` for endpoint form another domain

### DIFF
--- a/docs/set-up-configure.md
+++ b/docs/set-up-configure.md
@@ -65,3 +65,7 @@ dispatch(setEndpointPath('v1'));
 #### `setAccessToken( accessToken: string ): object`
 
 Dispatch this action to configure an access token to include in all requests. At the moment, _redux-json-api_ only supports authorizing requests through the `Authorization: Bearer <accessToken>` header.
+
+#### `setEndpointFetchMode( fetchMode: string ): object`
+
+Dispatch this action to configure Request.mode for fetch in all requests. It requires one argument. May be useful for endpoint under CORS.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 import keykey from 'keykey';
 
 export default keykey(
+  'API_SET_ENDPOINT_FETCH_MODE',
   'API_SET_ENDPOINT_HOST',
   'API_SET_ENDPOINT_PATH',
   'API_SET_ACCESS_TOKEN',

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -9,6 +9,7 @@ import {
   setAccessToken,
   setEndpointHost,
   setEndpointPath,
+  setEndpointFetchMode,
   IS_DELETING,
   IS_UPDATING
 } from '../src/jsonapi';
@@ -386,10 +387,15 @@ describe('Endpoint values', () => {
   it('should update to provided endpoint host and path', () => {
     const host = 'https://api.example.com';
     const path = '/api/v1';
+    const fetchMode = 'cors';
 
     expect(state.endpoint.host).toNotEqual(host);
     const stateWithHost = reducer(state, setEndpointHost(host));
     expect(stateWithHost.endpoint.host).toEqual(host);
+
+    expect(state.endpoint.fetchMode).toNotEqual(fetchMode);
+    const stateWithFetchMode = reducer(state, setEndpointFetchMode(fetchMode));
+    expect(stateWithFetchMode.endpoint.fetchMode).toEqual(fetchMode);
 
     expect(state.endpoint.path).toNotEqual(path);
     const stateWithPath = reducer(state, setEndpointPath(path));


### PR DESCRIPTION
By default `fetch` is not working via CORS. For enabling CORS `fetch` has special param `mode`.
This pull request exposes `setEndpointFetchMode(fetchMode: string)` method, which forces `mode` for all `apiRequest`s.
