### PR TITLE
58/relaxing redux thunk peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dixieio/redux-json-api#readme",
   "peerDependencies": {
-    "redux-thunk": "^1.0.0"
+    "redux-thunk": ">=1.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.4.5",


### PR DESCRIPTION
### Issue #58 
Issue is users are experiencing they are running a version 2.0.0 of the `redux-thunk` lib. and our current peer dependency is blocking their builds. 

### solution 
Relaxing the peer dependency for redux thunk to version 1.0.0 or higher.