### PR TITLE
Api Docs - Fix broken anchor links

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,10 +3,10 @@ API
 
 _redux-json-api_ provides a simple API for all four CRUD actions.
 
-- Create resource object using [createEntity](#createentity-resource-object--function)
-- Read endpoints through [readEndpoint](#readendpoint-endpoint-string--function)
-- Update resource with [updateEntity](#updateentity-resource-object--function)
-- Delete resource using [deleteEntity](#deleteentity-resource-object--function)
+- Create resource object using [createEntity](#createentity-resource-object--promise)
+- Read endpoints through [readEndpoint](#readendpoint-endpoint-string--promise)
+- Update resource with [updateEntity](#updateentity-resource-object--promise)
+- Delete resource using [deleteEntity](#deleteentity-resource-object--promise)
 
 ## Resource objects
 


### PR DESCRIPTION
The anchor links at the top of docs/api.md have not been working for a few weeks now.
Somehow I keep clicking on them.

Tiny pull request to fix the anchor links to put to the correct anchor tags further down in the document and make things better for all :)