### PR TITLE
Remove unnecessary keykey dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "immutable": "^3.7.6",
     "isomorphic-fetch": "^2.2.1",
-    "keykey": "^2.1.1",
     "pluralize": "^1.2.1",
     "redux-actions": "^0.9.1"
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,8 @@
-import keykey from 'keykey';
+// Action types of the library
+const actionTypes = {};
 
-export default keykey(
+// Format the elements
+[
   'API_SET_ENDPOINT_HOST',
   'API_SET_ENDPOINT_PATH',
   'API_SET_HEADERS',
@@ -17,4 +19,6 @@ export default keykey(
   'API_WILL_DELETE',
   'API_DELETED',
   'API_DELETE_FAILED'
-);
+].forEach(action => { actionTypes[action] = action; });
+
+export default actionTypes;


### PR DESCRIPTION
Hello!

`keykey` library is only used in one file and it depends on other two libraries:

```
+-- keykey@2.1.1
| `-- lru-cache@3.2.0
|   `-- pseudomap@1.0.2
```

The functionality is very simple, so I think it's a good idea to remove it and reduce the number of dependencies. I tested the changes and they work.