### PR TITLE
Enhances fetch requests to include credential cookies

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -144,7 +144,10 @@ export const readEndpoint = (endpoint, {
     const apiEndpoint = `${apiHost}${apiPath}/${endpoint}`;
 
     return new Promise((resolve, reject) => {
-      apiRequest(`${apiEndpoint}`, { headers })
+      apiRequest(`${apiEndpoint}`, {
+          headers,
+          credentials: 'include' 
+        })
         .then(json => {
           dispatch(apiRead({ endpoint, ...json }));
           onSuccess(json);

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -109,6 +109,7 @@ export const createEntity = (entity, {
       apiRequest(endpoint, {
         headers,
         method: 'POST',
+        credentials: 'include',
         body: JSON.stringify({
           data: entity
         })
@@ -179,6 +180,7 @@ export const updateEntity = (entity, {
       apiRequest(endpoint, {
         headers,
         method: 'PATCH',
+        credentials: 'include',
         body: JSON.stringify({
           data: entity
         })
@@ -215,7 +217,8 @@ export const deleteEntity = (entity, {
     return new Promise((resolve, reject) => {
       apiRequest(endpoint, {
         headers,
-        method: 'DELETE'
+        method: 'DELETE',
+        credentials: 'include'
       }).then(() => {
         dispatch(apiDeleted(entity));
         onSuccess();

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -145,9 +145,9 @@ export const readEndpoint = (endpoint, {
 
     return new Promise((resolve, reject) => {
       apiRequest(`${apiEndpoint}`, {
-          headers,
-          credentials: 'include' 
-        })
+        headers,
+        credentials: 'include'
+      })
         .then(json => {
           dispatch(apiRead({ endpoint, ...json }));
           onSuccess(json);


### PR DESCRIPTION
Resolves https://github.com/dixieio/redux-json-api/issues/65

Calls to fetch just need to have credentials: 'include', added to them to once again pass credential information across like jQuery ajax requests do by default.

Reference: https://developers.google.com/web/updates/2015/03/introduction-to-fetch#sending-credentials-with-a-fetch-request

> Sending Credentials with a Fetch Request
> 
> Should you want to make a fetch request with credentials such as cookies, you should set the credentials of the request to “include”.
> 
> fetch(url, {  
>   credentials: 'include'  
> })