### PR TITLE
Checks if getState() returns plain object or Immutable type

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -254,7 +254,7 @@ export const requireEntity = (entityType, endpoint = entityType, {
   return (dispatch, getState) => {
     return new Promise((resolve, reject) => {
       const state = getState();
-      const api = Imm.Iterable.isIterable(state) ? getState().get('api') : state.api;
+      const api = Imm.Iterable.isIterable(state) ? state.get('api') : state.api;
       if (api.hasOwnProperty(entityType)) {
         resolve();
         return onSuccess();

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -56,7 +56,8 @@ export const uploadFile = (file, {
   console.warn('uploadFile has been deprecated and will no longer be supported by redux-json-api https://github.com/dixieio/redux-json-api/issues/2');
 
   return (dispatch, getState) => {
-    const accessToken = getState().api.endpoint.accessToken;
+    const state = getState();
+    const {accessToken} = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
     const path = [companyId, fileableType, fileableId].filter(o => !!o).join('/');
     const url = `${__API_HOST__}/upload/${path}?access_token=${accessToken}`;
 
@@ -102,7 +103,8 @@ export const createEntity = (entity, {
   return (dispatch, getState) => {
     dispatch(apiWillCreate(entity));
 
-    const { host: apiHost, path: apiPath, headers } = getState().api.endpoint;
+    const state = getState()
+    const { host: apiHost, path: apiPath, headers } = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
     const endpoint = `${apiHost}${apiPath}/${entity.type}`;
 
     return new Promise((resolve, reject) => {
@@ -140,7 +142,8 @@ export const readEndpoint = (endpoint, {
   return (dispatch, getState) => {
     dispatch(apiWillRead(endpoint));
 
-    const { host: apiHost, path: apiPath, headers } = getState().api.endpoint;
+    const state = getState();
+    const { host: apiHost, path: apiPath, headers } = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
     const apiEndpoint = `${apiHost}${apiPath}/${endpoint}`;
 
     return new Promise((resolve, reject) => {
@@ -176,7 +179,8 @@ export const updateEntity = (entity, {
   return (dispatch, getState) => {
     dispatch(apiWillUpdate(entity));
 
-    const { host: apiHost, path: apiPath, headers } = getState().api.endpoint;
+    const state = getState();
+    const { host: apiHost, path: apiPath, headers } = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
     const endpoint = `${apiHost}${apiPath}/${entity.type}/${entity.id}`;
 
     return new Promise((resolve, reject) => {
@@ -214,7 +218,8 @@ export const deleteEntity = (entity, {
   return (dispatch, getState) => {
     dispatch(apiWillDelete(entity));
 
-    const { host: apiHost, path: apiPath, headers } = getState().api.endpoint;
+    const state = getState();
+    const { host: apiHost, path: apiPath, headers } = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
     const endpoint = `${apiHost}${apiPath}/${entity.type}/${entity.id}`;
 
     return new Promise((resolve, reject) => {
@@ -248,7 +253,7 @@ export const requireEntity = (entityType, endpoint = entityType, {
 
   return (dispatch, getState) => {
     return new Promise((resolve, reject) => {
-      const { api } = getState();
+      const api = Imm.Iterable.isIterable(state) ? getState().get('api') : state.api;
       if (api.hasOwnProperty(entityType)) {
         resolve();
         return onSuccess();

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -57,7 +57,7 @@ export const uploadFile = (file, {
 
   return (dispatch, getState) => {
     const state = getState();
-    const {accessToken} = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
+    const { accessToken } = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
     const path = [companyId, fileableType, fileableId].filter(o => !!o).join('/');
     const url = `${__API_HOST__}/upload/${path}?access_token=${accessToken}`;
 
@@ -103,7 +103,7 @@ export const createEntity = (entity, {
   return (dispatch, getState) => {
     dispatch(apiWillCreate(entity));
 
-    const state = getState()
+    const state = getState();
     const { host: apiHost, path: apiPath, headers } = Imm.Iterable.isIterable(state) ? state.get('api').endpoint : state.api.endpoint;
     const endpoint = `${apiHost}${apiPath}/${entity.type}`;
 
@@ -253,6 +253,7 @@ export const requireEntity = (entityType, endpoint = entityType, {
 
   return (dispatch, getState) => {
     return new Promise((resolve, reject) => {
+      const state = getState();
       const api = Imm.Iterable.isIterable(state) ? getState().get('api') : state.api;
       if (api.hasOwnProperty(entityType)) {
         resolve();


### PR DESCRIPTION
As a possible fix for #80 I wrote this PR. If this is something you want to include into the module I can write some tests as well. 

Text from the original issue see below:

Internally the module uses ImmutalbleJS for setting the api-states, but the api-reducer cannot be combined with existing reducers when the initialState of the store is Immutable:

For example:

```javascript
const redux = require('redux');
const Immutable = require('immutable');
const redux_immutable = require('redux-immutable');
const redux_thunk = require('redux-thunk').default;
const redux_json_api = require('redux-json-api');

const api = redux_json_api.reducer;

const reducers = redux_immutable.combineReducers({api});
const initialState = Immutable.Map();
const middlewares = redux.applyMiddleware(redux_thunk);
const store = redux.createStore(reducers, initialState, middlewares );

store.subscribe(() => console.log(store.getState().toJS()) )

store.dispatch(redux_json_api.setEndpointHost('http://ip.jsontest.com/'));
store.dispatch(redux_json_api.setAccessToken('access_token_123123'));

store.dispatch(redux_json_api.readEndpoint('/'))

```

This code results in:
`TypeError: Cannot read property 'endpoint' of undefined: getState().api.endpoint;`

The code looks like:
```javascript
const { host: apiHost, path: apiPath, headers } = getState().api.endpoint;
```

I think (in case the root-state is Immutable) this should be something like:
```javascript
const { host: apiHost, path: apiPath, headers } = getState().get('api').endpoint;
```