### PR TITLE
moving from isomorphic-fetch to fetch-everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "deep-equal": "^1.0.1",
-    "isomorphic-fetch": "^2.2.1",
+    "fetch-everywhere": "^1.0.5",
     "object-path-immutable": "^0.5.0",
     "pluralize": "^1.2.1",
     "redux-actions": "^0.9.1"

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -1,5 +1,5 @@
 import { createAction, handleActions } from 'redux-actions';
-import 'isomorphic-fetch';
+import 'fetch-everywhere';
 import imm from 'object-path-immutable';
 
 import {


### PR DESCRIPTION
Hey Folks, me again 👋 

This PR is to allow redux-json-api to work effectively in react-native, which it currently doesn't because of a known issue: https://github.com/matthew-andrews/isomorphic-fetch/issues/59

I don't really know the politics of the decision but it seems like isomorphic-fetch doesn't want to implement the fix that would solve this issue: https://github.com/matthew-andrews/isomorphic-fetch/pull/63 even though github have already implemented a fix themselves in their equivalent repository https://github.com/github/fetch/pull/253

As fetch is a standard there is literally no code change (as you can see by the PR) and everything just works as expected 👍 Let me know if you have any questions. 