### PR TITLE
adding lint guidelines to contrib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ To continuously watch and run tests, run the following:
 npm run test:watch
 ```
 
+### Linting
+Before submitting a PR check for stylistic errors by linting the project:
+```
+npm run lint
+```
+
 ### Building
 
 To build run:


### PR DESCRIPTION
I just submitted a code PR but forgot to run a linter (outside of the one running in my editor). I've added instructions to do this to the contribution guidelines.