### PR TITLE
add empty resources type to state before updating if the type doesn't exist

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -5,7 +5,8 @@ import imm from 'object-path-immutable';
 import {
   removeResourceFromState,
   updateOrInsertResourcesIntoState,
-  setIsInvalidatingForExistingResource
+  setIsInvalidatingForExistingResource,
+  insertResourcesTypeIntoState
 } from './state-mutation';
 import { apiRequest, noop, jsonContentTypes } from './utils';
 import {
@@ -329,7 +330,9 @@ export const reducer = handleActions({
   [API_WILL_UPDATE]: (state, { payload: resource }) => {
     const { type, id } = resource;
 
-    return setIsInvalidatingForExistingResource(state, { type, id }, IS_UPDATING)
+    const newState = state[type] ? state : insertResourcesTypeIntoState(state, type);
+
+    return setIsInvalidatingForExistingResource(newState, { type, id }, IS_UPDATING)
       .set('isUpdating', state.isUpdating + 1)
       .value();
   },

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -6,7 +6,7 @@ import {
   removeResourceFromState,
   updateOrInsertResourcesIntoState,
   setIsInvalidatingForExistingResource,
-  insertResourcesTypeIntoState
+  ensureResourceTypeInState
 } from './state-mutation';
 import { apiRequest, noop, jsonContentTypes } from './utils';
 import {
@@ -330,7 +330,7 @@ export const reducer = handleActions({
   [API_WILL_UPDATE]: (state, { payload: resource }) => {
     const { type, id } = resource;
 
-    const newState = state[type] ? state : insertResourcesTypeIntoState(state, type);
+    const newState = ensureResourceTypeInState(state, type);
 
     return setIsInvalidatingForExistingResource(newState, { type, id }, IS_UPDATING)
       .set('isUpdating', state.isUpdating + 1)

--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -179,9 +179,9 @@ export const setIsInvalidatingForExistingResource = (state, { type, id }, value 
     : imm(state).set(updatePath, value);
 };
 
-export const insertResourcesTypeIntoState = (state, type) => {
+export const ensureResourceTypeInState = (state, type) => {
   const path = [type, 'data'];
-  return state[type]
+  return hasOwnProperties(state, [type])
     ? state
     : imm(state).set(path, []).value();
 };

--- a/src/state-mutation.js
+++ b/src/state-mutation.js
@@ -178,3 +178,10 @@ export const setIsInvalidatingForExistingResource = (state, { type, id }, value 
     ? imm(state).del(updatePath)
     : imm(state).set(updatePath, value);
 };
+
+export const insertResourcesTypeIntoState = (state, type) => {
+  const path = [type, 'data'];
+  return state[type]
+    ? state
+    : imm(state).set(path, []).value();
+};

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -89,6 +89,42 @@ const state = {
   isDeleting: 0
 };
 
+const stateWithoutUsersResource = {
+  endpoint: {
+    host: null,
+    path: null,
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      Accept: 'application/vnd.api+json'
+    }
+  },
+  transactions: {
+    data: [
+      {
+        type: 'transactions',
+        id: '34',
+        attributes: {
+          description: 'ABC',
+          createdAt: '2016-02-12T13:34:01+0000',
+          updatedAt: '2016-02-19T11:52:43+0000',
+        },
+        relationships: {
+          task: {
+            data: null
+          }
+        },
+        links: {
+          self: 'http://localhost/transactions/34'
+        }
+      }
+    ]
+  },
+  isCreating: 0,
+  isReading: 0,
+  isUpdating: 0,
+  isDeleting: 0
+};
+
 const taskWithoutRelationship = {
   type: 'tasks',
   id: '43',
@@ -375,6 +411,13 @@ describe('Updating resources', () => {
     expect(state.users.data[0].attributes.name).toNotEqual(updatedUser.attributes.name);
     expect(updatedState.users.data[0].attributes.name).toEqual(updatedUser.attributes.name);
     zip([updatedState.users.data, state.users.data]).forEach((a, b) => expect(a.id).toEqual(b.id));
+  });
+
+  it('should be able to update a resource before type is in state', () => {
+    const userToUpdate = state.users.data[0];
+    const stateWithResourceType = reducer(stateWithoutUsersResource, apiWillUpdate(userToUpdate));
+    const updatedState = reducer(stateWithResourceType, apiUpdated(updatedUser));
+    expect(updatedState.users.data[0]).toEqual(updatedUser);
   });
 });
 

--- a/test/state-mutation.js
+++ b/test/state-mutation.js
@@ -6,7 +6,7 @@ import {
   setIsInvalidatingForExistingResource,
   updateOrInsertResource,
   updateOrInsertResourcesIntoState,
-  insertResourcesTypeIntoState
+  ensureResourceTypeInState
 } from '../src/state-mutation';
 
 import {
@@ -161,7 +161,7 @@ describe('[State mutation] Insertion of resources', () => {
 describe('[State mutation] Insertion of empty resources type', () => {
   it('should insert empty resources type into state', () => {
     const resourcesType = 'newResourcesType';
-    const updatedState = insertResourcesTypeIntoState(
+    const updatedState = ensureResourceTypeInState(
       state, resourcesType
     );
 
@@ -170,7 +170,7 @@ describe('[State mutation] Insertion of empty resources type', () => {
 
   it('should not mutate state if resources type exists', () => {
     const resourcesType = 'users';
-    const updatedState = insertResourcesTypeIntoState(
+    const updatedState = ensureResourceTypeInState(
       state, resourcesType
     );
 

--- a/test/state-mutation.js
+++ b/test/state-mutation.js
@@ -5,7 +5,8 @@ import {
   makeUpdateReverseRelationship,
   setIsInvalidatingForExistingResource,
   updateOrInsertResource,
-  updateOrInsertResourcesIntoState
+  updateOrInsertResourcesIntoState,
+  insertResourcesTypeIntoState
 } from '../src/state-mutation';
 
 import {
@@ -154,6 +155,26 @@ describe('[State mutation] Insertion of resources', () => {
     );
 
     expect(updatedState.topics.data.length).toEqual(topics.data.length);
+  });
+});
+
+describe('[State mutation] Insertion of empty resources type', () => {
+  it('should insert empty resources type into state', () => {
+    const resourcesType = 'newResourcesType';
+    const updatedState = insertResourcesTypeIntoState(
+      state, resourcesType
+    );
+
+    expect(updatedState[resourcesType].data.length).toEqual(0);
+  });
+
+  it('should not mutate state if resources type exists', () => {
+    const resourcesType = 'users';
+    const updatedState = insertResourcesTypeIntoState(
+      state, resourcesType
+    );
+
+    expect(updatedState[resourcesType].data).toEqual(state[resourcesType].data);
   });
 });
 


### PR DESCRIPTION
Resolves #98 

- Added a `insertResourcesTypeIntoState` to `state-mutation` file. This function inserts an empty resources collection to the state.
- Calling this function when handling `API_WILL_UPDATE` in the reducer, in order to prepare the state for `setIsInvalidatingForExistingResource` which assumes that the resource type exists as a property on the state.
- Added unit test.