### PR TITLE
Add ability to hydrate store

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@ import keykey from 'keykey';
 // Action types of the library
 export default keykey([
   'API_SET_AXIOS_CONFIG',
+  'API_HYDRATE',
   'API_WILL_CREATE',
   'API_CREATED',
   'API_CREATE_FAILED',

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -11,7 +11,7 @@ import {
 
 import { apiRequest, getPaginationUrl } from './utils';
 import {
-  API_SET_AXIOS_CONFIG, API_WILL_CREATE, API_CREATED, API_CREATE_FAILED, API_WILL_READ, API_READ, API_READ_FAILED, API_WILL_UPDATE, API_UPDATED, API_UPDATE_FAILED, API_WILL_DELETE, API_DELETED, API_DELETE_FAILED
+  API_SET_AXIOS_CONFIG, API_HYDRATE, API_WILL_CREATE, API_CREATED, API_CREATE_FAILED, API_WILL_READ, API_READ, API_READ_FAILED, API_WILL_UPDATE, API_UPDATED, API_UPDATE_FAILED, API_WILL_DELETE, API_DELETED, API_DELETE_FAILED
 } from './constants';
 
 // Resource isInvalidating values
@@ -20,6 +20,8 @@ export const IS_UPDATING = 'IS_UPDATING';
 
 // Action creators
 export const setAxiosConfig = createAction(API_SET_AXIOS_CONFIG);
+
+export const hydrateStore = createAction(API_HYDRATE);
 
 const apiWillCreate = createAction(API_WILL_CREATE);
 const apiCreated = createAction(API_CREATED);
@@ -198,6 +200,17 @@ export const requireResource = (resourceType, endpoint = resourceType) => {
 export const reducer = handleActions({
   [API_SET_AXIOS_CONFIG]: (state, { payload: axiosConfig }) => {
     return imm(state).set(['endpoint', 'axiosConfig'], axiosConfig).value();
+  },
+
+  [API_HYDRATE]: (state, { payload: resources }) => {
+    const entities = Array.isArray(resources.data) ? resources.data : [resources.data];
+
+    const newState = updateOrInsertResourcesIntoState(
+      state,
+      entities.concat(resources.included || [])
+    );
+
+    return imm(newState).value();
   },
 
   [API_WILL_CREATE]: (state) => {

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -7,6 +7,7 @@ import expect from 'expect';
 import {
   reducer,
   setAxiosConfig,
+  hydrateStore,
   IS_DELETING,
   IS_UPDATING
 } from '../src/jsonapi';
@@ -376,6 +377,27 @@ const responseDataWithOneToManyRelationship = {
 };
 
 const payloadWithNonMatchingReverseRelationships = require('./payloads/withNonMatchingReverseRelationships.json');
+
+describe('Hydration of store', () => {
+  it('should automatically organize new resource in new key on state', () => {
+    const updatedState = reducer(state, hydrateStore(taskWithoutRelationship));
+    expect(updatedState.tasks).toBeAn('object');
+  });
+
+  it('should add reverse relationship when inserting new resource', () => {
+    const updatedState = reducer(state, hydrateStore(taskWithTransaction));
+
+    const { data: taskRelationship } = updatedState.transactions.data[0].relationships.task;
+
+    expect(taskRelationship.type).toEqual(taskWithTransaction.data.type);
+    expect(taskRelationship.id).toEqual(taskWithTransaction.data.id);
+  });
+
+  it('should handle multiple resources', () => {
+    const updatedState = reducer(state, hydrateStore(multipleResources));
+    expect(updatedState.tasks).toBeAn('object');
+  });
+});
 
 describe('Creation of new resources', () => {
   it('should automatically organize new resource in new key on state', () => {


### PR DESCRIPTION
Previous conversation here https://github.com/dixieio/redux-json-api/pull/123

Upon application boot, you may want to hydrate the API store with existing information. As an outside user, I should not be dependent on the internal structure of the store for hydration. Instead, I should be able to pass in a JSON-API blob and get the same result that I would if I read the data from an endpoint.

In order to give the user flexibility in how to hydrate the store, as well as preserving server-side rendering compatibility, I have opted not to get hydration data from a global object, instead exposing the synchronous action `hydrateStore`.

It may not make sense to call this `hydrateStore` since you could use this for purposes other than hydration. However, `hydrateStore` seems to fit better with the paradigms in this repository.

Example usage:

```js
// store.js

import { createStore } from 'redux';
import rootReducer from 'reducers';
import { hydrateStore } from 'redux-json-api';

const store = createStore(rootReducer);

const jsonBlob = // some way of getting hydration data
store.dispatch(hydrateStore(jsonBlob));

export default store;
```

Once/if this idea is approved, I can add the necessary documentation for this functionality.