### PR TITLE
Fix isUpdating and isDeleting flags when update/delete fails

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -380,7 +380,7 @@ export const reducer = handleActions({
     const { type, id } = resource;
 
     return setIsInvalidatingForExistingResource(state, { type, id }, IS_UPDATING)
-      .set('isUpdating', state.isUpdating + 1)
+      .set('isUpdating', state.isUpdating - 1)
       .value();
   },
 
@@ -402,7 +402,7 @@ export const reducer = handleActions({
     const { type, id } = resource;
 
     return setIsInvalidatingForExistingResource(state, { type, id }, IS_DELETING)
-      .set('isDeleting', state.isDeleting + 1)
+      .set('isDeleting', state.isDeleting - 1)
       .value();
   }
 

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -25,6 +25,9 @@ const apiDeleted = createAction('API_DELETED');
 const apiWillUpdate = createAction('API_WILL_UPDATE');
 const apiWillDelete = createAction('API_WILL_DELETE');
 
+const apiUpdateFailed = createAction('API_UPDATE_FAILED');
+const apiDeleteFailed = createAction('API_DELETE_FAILED');
+
 const state = {
   endpoint: {
     host: null,
@@ -593,5 +596,21 @@ describe('apiRequest', () => {
       expect(data.statusText).toEqual('No Content');
       expect(data.status).toEqual(204);
     });
+  });
+});
+
+describe('progress flags', () => {
+  it('should update isUpdating flag properly when update fails', () => {
+    let updatedState = reducer(state, apiWillUpdate(state.users.data[0]));
+    expect(updatedState.isUpdating).toEqual(1);
+    updatedState = reducer(updatedState, apiUpdateFailed({ resource: state.users.data[0] }));
+    expect(updatedState.isUpdating).toEqual(0);
+  });
+
+  it('should update isDeleting flag properly when delete fails', () => {
+    let updatedState = reducer(state, apiWillDelete(state.users.data[0]));
+    expect(updatedState.isDeleting).toEqual(1);
+    updatedState = reducer(updatedState, apiDeleteFailed({ resource: state.users.data[0] }));
+    expect(updatedState.isDeleting).toEqual(0);
   });
 });


### PR DESCRIPTION
When update or delete fails, isUpdating/isDeleting flags should be decremented but they are incremented.