### PR TITLE
fix lib not generated - add prepublish task

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "rimraf lib && babel ./src -d lib",
     "test": "mocha --compilers js:babel-core/register --recursive",
     "test:watch": "npm test -- --watch",
-    "lint": "eslint . ./"
+    "lint": "eslint . ./",
+    "prepublish": "npm run lint && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
lib is missing, so adding prepublish task to add the lib folder directly. 