### PR TITLE
Optional overwrite of axiosConfig (v2)

### DIFF
--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -113,11 +113,11 @@ export const readEndpoint = (endpoint, {
   };
 };
 
-export const updateResource = (resource) => {
+export const updateResource = (resource, config) => {
   return (dispatch, getState) => {
     dispatch(apiWillUpdate(resource));
 
-    const { axiosConfig } = getState().api.endpoint;
+    const { axiosConfig } = config || getState().api.endpoint;
     const endpoint = `${resource.type}/${resource.id}`;
 
     const options = {
@@ -145,11 +145,11 @@ export const updateResource = (resource) => {
   };
 };
 
-export const deleteResource = (resource) => {
+export const deleteResource = (resource, config) => {
   return (dispatch, getState) => {
     dispatch(apiWillDelete(resource));
 
-    const { axiosConfig } = getState().api.endpoint;
+    const { axiosConfig } = config || getState().api.endpoint;
     const endpoint = `${resource.type}/${resource.id}`;
 
     const options = {


### PR DESCRIPTION
Allow the ability to overwrite axiosConfig for update & delete resource requests. See PR #146.

This allows the client to make requests at different endpoints. 

In the example below, the endpoint for v2 is overwritten with v2.1. 

```js
const customConfig =  const config = {
  ...store.getState().api.endpoint.axiosConfig,
  baseURL: `https://host.com/v2.1/`, // rather than v2
};
dispatch(deleteResource(entity, customConfig));
```

Other `axiosConfig` properties could be overridden as well, such as host, timeout, etc.